### PR TITLE
♻️ Refactor: entity와 UserDetails 분리

### DIFF
--- a/src/main/java/com/zb/deuggeun/security/domain/CustomUserDetails.java
+++ b/src/main/java/com/zb/deuggeun/security/domain/CustomUserDetails.java
@@ -1,6 +1,5 @@
 package com.zb.deuggeun.security.domain;
 
-import com.zb.deuggeun.member.entity.Member;
 import java.util.ArrayList;
 import java.util.Collection;
 import lombok.RequiredArgsConstructor;
@@ -11,23 +10,23 @@ import org.springframework.security.core.userdetails.UserDetails;
 @RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
 
-  private final transient Member member;
+  private final transient UserDetailsDomain details;
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
     Collection<GrantedAuthority> list = new ArrayList<>();
-    list.add(new SimpleGrantedAuthority(member.getRole().name()));
+    list.add(new SimpleGrantedAuthority(details.role().name()));
     return list;
   }
 
   @Override
   public String getPassword() {
-    return member.getPassword();
+    return details.password();
   }
 
   @Override
   public String getUsername() {
-    return member.getEmail();
+    return details.email();
   }
 
   @Override

--- a/src/main/java/com/zb/deuggeun/security/domain/UserDetailsDomain.java
+++ b/src/main/java/com/zb/deuggeun/security/domain/UserDetailsDomain.java
@@ -1,0 +1,30 @@
+package com.zb.deuggeun.security.domain;
+
+import com.zb.deuggeun.member.entity.Member;
+import com.zb.deuggeun.member.type.Role;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UserDetailsDomain(
+    @NotNull
+    Long id,
+
+    @NotBlank
+    String email,
+
+    @NotBlank
+    String password,
+
+    @NotNull
+    Role role
+) {
+
+  public static UserDetailsDomain fromEntity(Member member) {
+    return new UserDetailsDomain(
+        member.getId(),
+        member.getEmail(),
+        member.getPassword(),
+        member.getRole()
+    );
+  }
+}

--- a/src/main/java/com/zb/deuggeun/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/zb/deuggeun/security/service/CustomUserDetailsService.java
@@ -3,6 +3,7 @@ package com.zb.deuggeun.security.service;
 import com.zb.deuggeun.common.exception.ExceptionCode;
 import com.zb.deuggeun.member.repository.MemberRepository;
 import com.zb.deuggeun.security.domain.CustomUserDetails;
+import com.zb.deuggeun.security.domain.UserDetailsDomain;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -17,7 +18,11 @@ public class CustomUserDetailsService implements UserDetailsService {
 
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    return new CustomUserDetails(memberRepository.findByEmail(username)
+    return new CustomUserDetails(getUserDetailsDomain(username));
+  }
+
+  private UserDetailsDomain getUserDetailsDomain(String username) {
+    return UserDetailsDomain.fromEntity(memberRepository.findByEmail(username)
         .orElseThrow(() -> new UsernameNotFoundException(
             ExceptionCode.ENTITY_NOT_FOUND.getMessage()
         )));


### PR DESCRIPTION
### 변경사항

**AS-IS**
CustomUserDetails에서 Entity인 Member를 그대로 field로 들고 있음

**TO-BE**
필요한 필드만 들고있는 도메인 생성 후 적용
→ Member 엔티티와 CustomUserDetails 분리